### PR TITLE
Add .NET Standard 1.6 platform in search filter.

### DIFF
--- a/config/layout-renderers.json
+++ b/config/layout-renderers.json
@@ -1836,9 +1836,13 @@
   },
   {
     "name": "appsettings",
-    "description": "${appsettings} for .NET Standard and appsettings.json config files",
+    "description": "It be used to access appsettings.json for netcoreapp",
     "page": "https://github.com/linmasaki/NLog.Appsettings.Standard",
     "package": "NLog.Appsettings.Standard",
+    "platforms": [
+      "netstandard1.6",
+      "netstandard2.0"
+    ],
     "external": true,
     "category": "Environment and config files"
   },

--- a/config/searchPage.js
+++ b/config/searchPage.js
@@ -32,6 +32,7 @@ var app = new Vue({
             "net45": { name: ".NET 4.5" },
             "netstandard1.3": { name: ".NET Standard 1.3" },
             "netstandard1.5": { name: ".NET Standard 1.5" },
+            "netstandard1.6": { name: ".NET Standard 1.6" },
             "netstandard2.0": { name: ".NET Standard 2.0" },
             "ios": { name: "Xamarin iOs" },
             "android": { name: "Xamarin Android" },


### PR DESCRIPTION
Sorry, I can't find ".NET Standard 1.6" option in search select items, so I added it in the js file. If there any reason you don't want show it in select list, please tell me and ignore this commit. Thank you!