### PR TITLE
Update NLog.Redis link

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -690,10 +690,9 @@
     },
     {
         "name": "Redis",
-        "page": "https://github.com/richclement/NLog.Redis",
-        "package": "NLog.Redis",
+        "page": "https://github.com/NLog/NLog.Redis",
+        "package": "NLog.Targets.Redis",
         "description": "Writes NLog messages to Redis",
-        "external": true,
         "category": "Integrations"
     },
     {


### PR DESCRIPTION
This updates the docs pages to reflect NLog.Targets.Redis is now under NLog.

This closes https://github.com/NLog/NLog.Redis/issues/27