### PR TITLE
Added official Sentry integration

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -712,7 +712,15 @@
         "category": "Integrations (Cloud)"
     },
     {
-        "name": "Sentry",
+        "name": "Sentry (Unified SDK)",
+        "page": "https://github.com/getsentry/sentry-dotnet",
+        "package": "Sentry.NLog",
+        "description": "Official NLog integration for Sentry - Open-source error tracking that helps developers monitor and fix crashes in real time.",
+        "external": true,
+        "category": "Integrations (Cloud)"
+    },
+    {
+        "name": "Sentry (Raven sdk)",
         "page": "https://github.com/CurtisInstruments/NLog.Targets.Sentry",
         "package": "NLog.Targets.Sentry3",
         "description": "Writes NLog messages to https://www.sentry.io",


### PR DESCRIPTION
This PR adds a link on the config docs page for the official Sentry NLog integration. The existing link goes to a package that works with the older SDK of sentry (`SharpRaven`), and works on older framework versions, but the package added here is built on the official .NET SDK for sentry, and in the same repository.