### PR TITLE
Update 2019-03-20-nlog-4-6-is-live.md

### DIFF
--- a/_posts/2019-03-20-nlog-4-6-is-live.md
+++ b/_posts/2019-03-20-nlog-4-6-is-live.md
@@ -75,7 +75,12 @@ In the XML configuration you could now variables in the level attributes (minlev
 </nlog>
 ```
 
-Note: for performance reasons, ${var:myLevel} or other layout renderers won't work.
+NLog ver. 4.6.7 adds support for using `${var:myLevel}` or other layout renderers. Allowing one to update filters at runtime like this:
+
+```csharp
+LogManager.Configuration.Variables["myLevel"] = "Debug";
+LogManager.ReconfigExistingLoggers();
+```
 
 ### Added default action for filtering
 


### PR DESCRIPTION
Adjusting statement about not being able to use layout renderer in filtering-rules.