### PR TITLE
Add NLog.Targets.GraylogHttp

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -651,6 +651,14 @@
         "category": "Integrations"
     },
     {
+        "name": "NLog.Targets.GraylogHttp",
+        "page": "https://github.com/dustinchilson/NLog.Targets.GraylogHttp",
+        "package": "NLog.Targets.GraylogHttp",
+        "description": "NLog target that pushes log messages to Graylog using the Http input.",
+        "external": true,
+        "category": "Integrations"
+    },
+    {
         "name": "EasyGelf",
         "page": "https://github.com/Pliner/EasyGelf",
         "package": "EasyGelf.NLog",


### PR DESCRIPTION
I'm not the author but I've been using `NLog.Targets.GraylogHttp` in multiple services that I manage for a quite long time and it's been proven to work very good.

https://github.com/dustinchilson/NLog.Targets.GraylogHttp

It's currently 1.0.0 version for a quite a while and it's been very stable.