### PR TITLE
Added NLog.Targets.Loki as an NLog target.

### DIFF
--- a/config/targets.json
+++ b/config/targets.json
@@ -715,6 +715,14 @@
         "category": "Integrations (Cloud)"
     },
     {
+        "name": "Loki",
+        "page": "https://github.com/corentinaltepe/nlog.loki",
+        "package": "NLog.Targets.Loki",
+        "description": "Writes NLog messages to Grafana Loki https://github.com/grafana/loki",
+        "external": true,
+        "category": "Integrations (Cloud)"
+    },
+    {
         "name": "Loupe",
         "page": "https://github.com/GibraltarSoftware/Gibraltar.Agent.NLog2",
         "package": "Gibraltar.Agent.NLog4",


### PR DESCRIPTION
Hello. I'd like to reference `NLog.Targets.Loki` if that's okay with you.

Repository: https://github.com/corentinaltepe/nlog.loki
On Nuget.org: https://www.nuget.org/packages/NLog.Targets.Loki/

Note: the package was previously named `CorentinAltepe.NLog.Loki` but was just very recently renamed and published as `NLog.Targets.Loki`.